### PR TITLE
Move entries to top of searchlist and show more of the file path

### DIFF
--- a/sed
+++ b/sed
@@ -1,0 +1,2 @@
+ -i s/~/\/home\/maxine\//g
+ -i s/~/\/home\/maxine\//g


### PR DESCRIPTION
# Features
- Move entries to top of searchlist after they are selected (DOES NOT WORK WITH --watch)
- dmenu search shows more of the directories and hides $USER_HOME

# Changes
- Added a $HISTORYLIST variable for the history list
	- $HISTORYLIST is updated on every search
	- $HISTORYLIST is used to move lines to top of $SEARCHLIST after search and on generate
- Updated rofi prompt to "Bolt Launch"
- Updated FZF search to show two folders up for files
- Updated dmenu search: 
	- shows four folders up for files 
	- replaces $USER_HOME (top of the file) with ~/
	- adds ../ if the path is longer than four folders
- Updated search to use DuckDuckGo instead of Google
- Updated FZF margins from 15% 15% to 5%, 10%

# Code Changes
- Factored out rofi launch into function
- Factored out dmenu launch into function


# Dependencies
- ed